### PR TITLE
Add fromPromise

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -4,10 +4,10 @@
     "node"
   ],
   "license": "MIT",
-  "repository": {                                                          
-      "type": "git",                                                         
-      "url": "git://github.com/nwolverson/purescript-aff-promise.git"
-   },  
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/nwolverson/purescript-aff-promise.git"
+  },
   "ignore": [
     "**/.*",
     "node_modules",
@@ -15,6 +15,7 @@
     "output"
   ],
   "dependencies": {
-    "purescript-aff": "~2.0.0"
+    "purescript-aff": "~2.0.0",
+    "purescript-foreign": "^3.0.0"
   }
 }

--- a/src/Control/Promise.js
+++ b/src/Control/Promise.js
@@ -14,3 +14,11 @@ exports.promise = function (f) {
     });
   };
 };
+
+exports.thenImpl = function(promise){
+  return function(errCB){
+    return function(succCB){
+      promise.then(succCB, errCB);
+    };
+  };
+};

--- a/src/Control/Promise.purs
+++ b/src/Control/Promise.purs
@@ -1,13 +1,30 @@
-module Control.Promise (fromAff, Promise()) where
+module Control.Promise (fromAff, fromPromise, Promise()) where
 
 import Prelude
+import Control.Alt ((<|>))
+import Control.Monad.Aff (makeAff, Aff, runAff)
 import Control.Monad.Eff (Eff)
-import Control.Monad.Aff (Aff, runAff)
+import Control.Monad.Eff.Exception (Error, error)
+import Control.Monad.Except (runExcept)
+import Data.Either (either)
+import Data.Foreign (Foreign, unsafeReadTagged)
+import Data.Foreign.Class (read)
 
 foreign import data Promise :: * -> *
 
 foreign import promise :: forall eff a b.
   ((a -> Eff eff Unit) -> (b -> Eff eff Unit) -> Eff eff Unit) -> Eff eff (Promise a)
+foreign import thenImpl :: forall a b e.
+  Promise a -> (Foreign -> Eff e b) -> (a -> Eff e b) -> Eff e Unit
 
 fromAff :: forall eff a. Aff eff a -> Eff eff (Promise a)
 fromAff aff = promise (\succ err -> void $ runAff err succ aff)
+
+coerce :: Foreign -> Error
+coerce fn =
+  either (\_ -> error "Promise failed, couldn't extract JS Error or String")
+         id
+         (runExcept ((unsafeReadTagged "Error" fn) <|> (error <$> read fn)))
+
+fromPromise :: forall eff a. Promise a -> Aff eff a
+fromPromise p = makeAff (\errCB succCB -> thenImpl p (errCB <<< coerce) succCB)

--- a/src/Control/Promise.purs
+++ b/src/Control/Promise.purs
@@ -1,4 +1,4 @@
-module Control.Promise (fromAff, fromPromise, Promise()) where
+module Control.Promise (fromAff, toAff, Promise()) where
 
 import Prelude
 import Control.Alt ((<|>))
@@ -26,5 +26,9 @@ coerce fn =
          id
          (runExcept ((unsafeReadTagged "Error" fn) <|> (error <$> read fn)))
 
-fromPromise :: forall eff a. Promise a -> Aff eff a
-fromPromise p = makeAff (\errCB succCB -> thenImpl p (errCB <<< coerce) succCB)
+-- | Convert a Promise into an Aff.
+-- | When the promise rejects, we attempt to
+-- | coerce the error value into an actual JavaScript Error object. We can do this
+-- | with Error objects or Strings. Anything else gets a "dummy" Error object.
+toAff :: forall eff a. Promise a -> Aff eff a
+toAff p = makeAff (\errCB succCB -> thenImpl p (errCB <<< coerce) succCB)


### PR DESCRIPTION
I took a stab at #1 . Obviously the hard part is not knowing what you'll get in the error callback but Aff wants an Error, so I made the "coerce" function for that. Either it's already a JS Error, than we can use that, or it's a String, then we make an Error out of it. So far so good, and this should cover the vast majority of real life JS integration use cases. 

But what to do if it's not one of these two? I'm honestly not sure. Right now I just make an Error with some explanatory text, but would like to know what you think.