### PR TITLE
Add a toAff' for native code that does not fail with Errors or strings

### DIFF
--- a/test/Main.js
+++ b/test/Main.js
@@ -1,3 +1,4 @@
 exports.helloPromise = Promise.resolve("Hello");
 exports.goodbyePromise = Promise.reject("Goodbye");
 exports.errPromise = Promise.reject(new Error('err'));
+exports.customErrPromise = Promise.reject({ code: "err" });


### PR DESCRIPTION
For JavaScript code that does not reject promises with an Error or a
string, users of the toAff API lose tha ability to have meaningful
errors. This adds a new API that allows the user of the API to provide a
custom conversion function that takes the reject value as a Foreign and
provides an Error object instead.