### PR TITLE
Simplify example with toAffE

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ The response can then be converted to an `Aff` and consumed easily:
 import Control.Promise as Promise
 
 fetch :: String -> Aff String
-fetch url = liftEffect (fetchImpl url) >>= Promise.toAff
+fetch = fetchImpl >>> Promise.toAffE
 ```
 
 # Documentation


### PR DESCRIPTION
Figured it would be good to feature the simpler syntax.

We could show an example of both `toAff` and `toAffE` if you'd like.