### PR TITLE
Unwrapped promises.

### DIFF
--- a/src/Control/Promise.js
+++ b/src/Control/Promise.js
@@ -1,6 +1,6 @@
 // module Control.Promise
 
-exports.promise = function (f) {
+exports.promiseE = function (f) {
   return function () {
     return new Promise(function (success, error) {
       var succF = function (s) { return function() { return success(s); } };
@@ -13,6 +13,19 @@ exports.promise = function (f) {
       }
     });
   };
+};
+
+exports.promise = function (f) {
+    return new Promise(function (success, error) {
+      var succF = function (s) { return function() { return success(s); } };
+      var failF = function (s) { return function() { return error(s); } };
+
+      // This indicates the aff was wrong?
+      try { f(succF)(failF)(); }
+      catch (e) {
+        error(e);
+      }
+    });
 };
 
 exports.thenImpl = function(promise) {

--- a/src/Control/Promise.js
+++ b/src/Control/Promise.js
@@ -1,6 +1,6 @@
 // module Control.Promise
 
-exports.promiseE = function (f) {
+exports.promise = function (f) {
   return function () {
     return new Promise(function (success, error) {
       var succF = function (s) { return function() { return success(s); } };
@@ -15,7 +15,7 @@ exports.promiseE = function (f) {
   };
 };
 
-exports.promise = function (f) {
+exports.promisePure = function (f) {
     return new Promise(function (success, error) {
       var succF = function (s) { return function() { return success(s); } };
       var failF = function (s) { return function() { return error(s); } };

--- a/src/Control/Promise.purs
+++ b/src/Control/Promise.purs
@@ -1,6 +1,6 @@
 module Control.Promise
   ( fromAff
-  , fromAffE
+  , fromAffPure
   , toAff
   , toAff'
   , toAffE
@@ -27,11 +27,11 @@ foreign import data Promise :: Type -> Type
 
 type role Promise representational
 
-foreign import promiseE ::
+foreign import promise ::
   forall a b.
   ((a -> Effect Unit) -> (b -> Effect Unit) -> Effect Unit) -> Effect (Promise a)
 
-foreign import promise ::
+foreign import promisePure ::
   forall a b.
   (Fn2 (a -> Effect Unit) (b -> Effect Unit) (Effect Unit)) -> Promise a
 
@@ -40,11 +40,11 @@ foreign import thenImpl ::
   Promise a -> (EffectFn1 Foreign b) -> (EffectFn1 a b) -> Effect Unit
 
 -- | Convert an Aff into a Promise.
-fromAffE :: forall a. Aff a -> Effect (Promise a)
-fromAffE aff = promiseE (\succ err -> runAff_ (either err succ) aff)
+fromAff :: forall a. Aff a -> Effect (Promise a)
+fromAff aff = promise (\succ err -> runAff_ (either err succ) aff)
 
-fromAff :: forall a. Aff a -> Promise a
-fromAff aff = promise (mkFn2 (\succ err -> runAff_ (either err succ) aff))
+fromAffPure :: forall a. Aff a -> Promise a
+fromAffPure aff = promisePure (mkFn2 (\succ err -> runAff_ (either err succ) aff))
 
 coerce :: Foreign -> Error
 coerce fn =

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -77,15 +77,19 @@ main = launchAff_ $ flip runReaderT "" do
   suite "round-trip" do
     test "success" do
       timeout 100 $ do
-        promise <- liftEffect $ Promise.fromAff $ pure 42
+        promise <- liftEffect $ Promise.fromAffE $ pure 42
         res <- Promise.toAff promise
         assert "round-trip result is 42" $ res == 42
+    test "fromAff" do
+      timeout 100 do
+        res <- Promise.toAff $ Promise.fromAff $ pure 8008
+        assert "round-trip result for toAffE is 8008" $ res == 8008
     test "toAffE" do
       timeout 100 do
-        res <- Promise.toAffE $ Promise.fromAff $ pure 123
+        res <- Promise.toAffE $ Promise.fromAffE $ pure 123
         assert "round-trip result for toAffE is 123" $ res == 123
     test "error" do
-      promise <- liftEffect $ Promise.fromAff $ throwError $ error "err123"
+      promise <- liftEffect $ Promise.fromAffE $ throwError $ error "err123"
       res <- attempt $ Promise.toAff promise
       shouldEqual "err123" $ either message (const "-") res
   where

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -77,19 +77,19 @@ main = launchAff_ $ flip runReaderT "" do
   suite "round-trip" do
     test "success" do
       timeout 100 $ do
-        promise <- liftEffect $ Promise.fromAffE $ pure 42
+        promise <- liftEffect $ Promise.fromAff $ pure 42
         res <- Promise.toAff promise
         assert "round-trip result is 42" $ res == 42
-    test "fromAff" do
+    test "fromAffPure" do
       timeout 100 do
-        res <- Promise.toAff $ Promise.fromAff $ pure 8008
-        assert "round-trip result for toAffE is 8008" $ res == 8008
+        res <- Promise.toAff $ Promise.fromAffPure $ pure 8008
+        assert "round-trip result for fromAffPure is 8008" $ res == 8008
     test "toAffE" do
       timeout 100 do
-        res <- Promise.toAffE $ Promise.fromAffE $ pure 123
+        res <- Promise.toAffE $ Promise.fromAff $ pure 123
         assert "round-trip result for toAffE is 123" $ res == 123
     test "error" do
-      promise <- liftEffect $ Promise.fromAffE $ throwError $ error "err123"
+      promise <- liftEffect $ Promise.fromAff $ throwError $ error "err123"
       res <- attempt $ Promise.toAff promise
       shouldEqual "err123" $ either message (const "-") res
   where


### PR DESCRIPTION
Currently it's only possible to convert `Aff` into a `Promise` by having it inside `Effect`. We currently have a need to do this without touching `Effect` at all. After looking at a [different library]( https://github.com/thimoteus/purescript-promises), I'm under the impression that wrapping it in `Effect` might not be necessary (I'm not familiar with JavaScript, so that's a huge assumption on my end). So I ported / adapted the approach over here.

At the moment we're using it with `unsafePerformEffect` to unwrap it, which is far from ideal.